### PR TITLE
clipboard unnamed

### DIFF
--- a/autoload/operator/suddendeath.vim
+++ b/autoload/operator/suddendeath.vim
@@ -10,10 +10,10 @@ function! operator#suddendeath#do(motion_wise)
     return
   endif
   let put = getpos("']")[1] == line('$') ? 'p' : 'P'
-  normal! `[V`]d
-  let str = split(@", '\n')
-  let @" = s:to_suddendeath(str)
-  execute 'normal!' put
+  execute 'normal!' '`[V`]"' . v:register . 'd'
+  let str = split(getreg(v:register), '\n')
+  call setreg(v:register, s:to_suddendeath(str), 'V')
+  execute 'normal!' '"' . v:register . put
 endfunction
 
 


### PR DESCRIPTION
`clipboard`に`unnamed`か`unnamedplus`が含まれていると
内部で`p`を使用した際に`"`ではなく`*`や`+`が使われる為に正常に動作しません
それだけなら`execute 'normal!' '""' . put`でも良かったのですが、
ついでにレジスタ指定(`["x]<Plug>(operator-suddendeath)`)できるようにしてみました

```
					*v:register* *register-variable*
v:register	現在のノーマルモードコマンドに適用されるレジスタの名前 (そのコ
		マンドが実際にレジスタを使うかどうかには依らない)。または、現
		在実行しているノーマルモードマッピング用のレジスタの名前 (レジ
		スタを使うカスタムコマンドの中で使う)。レジスタが指定されなかっ
		たときはデフォルトレジスタ '"' になる。'clipboard' に
		"unnamed" か "unnamedplus" が含まれているときはデフォルトはそ
		れぞれ '*' か '+' になる。
		|getreg()| と |setreg()| も参照。
```