### PR TITLE
Use operator#user#register function

### DIFF
--- a/autoload/operator/suddendeath.vim
+++ b/autoload/operator/suddendeath.vim
@@ -10,10 +10,11 @@ function! operator#suddendeath#do(motion_wise)
     return
   endif
   let put = getpos("']")[1] == line('$') ? 'p' : 'P'
-  execute 'normal!' '`[V`]"' . v:register . 'd'
-  let str = split(getreg(v:register), '\n')
-  call setreg(v:register, s:to_suddendeath(str), 'V')
-  execute 'normal!' '"' . v:register . put
+  let reg = operator#user#register()
+  execute 'normal!' '`[V`]"' . reg . 'd'
+  let str = split(getreg(reg), '\n')
+  call setreg(reg, s:to_suddendeath(str), 'V')
+  execute 'normal!' '"' . reg . put
 endfunction
 
 


### PR DESCRIPTION
operator-userでのregister指定は`v:register`ではなく`operator#user#register()`を
使わないといけないみたいなので修正しました

```
						*operator#user#register()*
operator#user#register()
			Return the name of the last register which is given to
			a custom operator defined by |operator-user|.  Use
			this function instead of |v:register|, because
			v:register might be overwritten if a custom operator
			is combined with a custom text object.
```